### PR TITLE
Allow to use Long Press to open select box

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -44,14 +44,14 @@ class _MyHomePageState extends State<MyHomePage> {
     "Pork grilled",
     "Vegetables as is",
     "Cheese as is",
-    "Bread tasty"
+    "Bread tasty",
   ];
 
   List<String> _portionSize = [
     "Small portion",
     "Medium portion",
     "Large portion",
-    "Huge portion"
+    "Huge portion",
   ];
 
   List<String> _numbers = ["1.0", "2.0", "3.0", "4.0", "5.0", "6.0", "7.0"];
@@ -85,29 +85,37 @@ class _MyHomePageState extends State<MyHomePage> {
     final appBar = PreferredSize(
         child: Container(
           decoration: BoxDecoration(
-              color: Color.fromRGBO(246, 247, 249, 1),
-              border: BorderDirectional(
-                  bottom: BorderSide(width: 1, color: Colors.black12))),
+            color: Color.fromRGBO(246, 247, 249, 1),
+            border: BorderDirectional(
+              bottom: BorderSide(width: 1, color: Colors.black12),
+            ),
+          ),
           child: Padding(
               padding: EdgeInsets.only(left: 16, bottom: 24),
-              child: Column(
-                  verticalDirection: VerticalDirection.up,
-                  children: <Widget>[
-                    Container(
-                        alignment: AlignmentDirectional.centerStart,
-                        child: Text("Add Food",
-                            style: TextStyle(
-                                fontSize: 26,
-                                color: Colors.black,
-                                fontWeight: FontWeight.bold))),
-                    Container(
-                        alignment: AlignmentDirectional.centerStart,
-                        child: Text("Journal",
-                            style: TextStyle(
-                                fontSize: 12,
-                                color: Colors.black38,
-                                fontWeight: FontWeight.bold)))
-                  ])),
+              child: Column(verticalDirection: VerticalDirection.up, children: <Widget>[
+                Container(
+                  alignment: AlignmentDirectional.centerStart,
+                  child: Text(
+                    "Add Food",
+                    style: TextStyle(
+                      fontSize: 26,
+                      color: Colors.black,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                Container(
+                  alignment: AlignmentDirectional.centerStart,
+                  child: Text(
+                    "Journal",
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: Colors.black38,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                )
+              ])),
         ),
         preferredSize: Size.fromHeight(90));
 
@@ -129,9 +137,10 @@ class _MyHomePageState extends State<MyHomePage> {
                     margin: EdgeInsets.only(left: 4),
                     child: Column(
                       children: <Widget>[
-                        Text(_foodVariants[selectedFoodVariants],
-                            style: TextStyle(
-                                fontSize: 26, fontWeight: FontWeight.bold))
+                        Text(
+                          _foodVariants[selectedFoodVariants],
+                          style: TextStyle(fontSize: 26, fontWeight: FontWeight.bold),
+                        )
                       ],
                     )),
                 Container(
@@ -139,11 +148,7 @@ class _MyHomePageState extends State<MyHomePage> {
                     alignment: AlignmentDirectional.centerStart,
                     margin: EdgeInsets.only(left: 4),
                     child: Column(
-                      children: <Widget>[
-                        Text(_numbers[selectedPortionCounts] +
-                            "   " +
-                            _portionSize[selectedPortionSize])
-                      ],
+                      children: <Widget>[Text(_numbers[selectedPortionCounts] + "   " + _portionSize[selectedPortionSize])],
                     )),
                 SizedBox(height: 5.0),
                 _getFoodContainsRow(),
@@ -154,8 +159,7 @@ class _MyHomePageState extends State<MyHomePage> {
                     children: <Widget>[
                       MealSelector(data: _meals, label: "To which meal?"),
                       SizedBox(height: 20.0),
-                      MealSelector(
-                          data: _food, label: "Search our database by name"),
+                      MealSelector(data: _food, label: "Search our database by name"),
                       Padding(
                         padding: EdgeInsets.fromLTRB(0, 8, 0, 0),
                         child: Container(
@@ -168,17 +172,14 @@ class _MyHomePageState extends State<MyHomePage> {
                                   child: Padding(
                                       child: DirectSelectList<String>(
                                           values: _foodVariants,
+                                          useLongPressGesture: true,
                                           onUserTappedListener: () {
                                             _showScaffold();
                                           },
-                                          defaultItemIndex:
-                                              selectedFoodVariants,
-                                          itemBuilder: (String value) =>
-                                              getDropDownMenuItem(value),
-                                          focusedItemDecoration:
-                                              _getDslDecoration(),
-                                          onItemSelectedListener:
-                                              (item, index, context) {
+                                          defaultItemIndex: selectedFoodVariants,
+                                          itemBuilder: (String value) => getDropDownMenuItem(value),
+                                          focusedItemDecoration: _getDslDecoration(),
+                                          onItemSelectedListener: (item, index, context) {
                                             setState(() {
                                               selectedFoodVariants = index;
                                             });
@@ -215,14 +216,10 @@ class _MyHomePageState extends State<MyHomePage> {
                                                 _showScaffold();
                                               },
                                               values: _numbers,
-                                              defaultItemIndex:
-                                                  selectedPortionCounts,
-                                              itemBuilder: (String value) =>
-                                                  getDropDownMenuItem(value),
-                                              focusedItemDecoration:
-                                                  _getDslDecoration(),
-                                              onItemSelectedListener:
-                                                  (item, index, context) {
+                                              defaultItemIndex: selectedPortionCounts,
+                                              itemBuilder: (String value) => getDropDownMenuItem(value),
+                                              focusedItemDecoration: _getDslDecoration(),
+                                              onItemSelectedListener: (item, index, context) {
                                                 setState(() {
                                                   selectedPortionCounts = index;
                                                 });
@@ -243,14 +240,10 @@ class _MyHomePageState extends State<MyHomePage> {
                                       child: Padding(
                                           child: DirectSelectList<String>(
                                               values: _portionSize,
-                                              defaultItemIndex:
-                                                  selectedPortionSize,
-                                              itemBuilder: (String value) =>
-                                                  getDropDownMenuItem(value),
-                                              focusedItemDecoration:
-                                                  _getDslDecoration(),
-                                              onItemSelectedListener:
-                                                  (item, index, context) {
+                                              defaultItemIndex: selectedPortionSize,
+                                              itemBuilder: (String value) => getDropDownMenuItem(value),
+                                              focusedItemDecoration: _getDslDecoration(),
+                                              onItemSelectedListener: (item, index, context) {
                                                 setState(() {
                                                   selectedPortionSize = index;
                                                 });
@@ -267,8 +260,10 @@ class _MyHomePageState extends State<MyHomePage> {
                       Row(children: <Widget>[
                         Expanded(
                             child: RaisedButton(
-                          child: const Text('ADD TO JOURNAL',
-                              style: TextStyle(color: Colors.blueAccent)),
+                          child: const Text(
+                            'ADD TO JOURNAL',
+                            style: TextStyle(color: Colors.blueAccent),
+                          ),
                           onPressed: () {},
                         ))
                       ]),
@@ -322,9 +317,10 @@ class MealSelector extends StatelessWidget {
     return Column(
       children: [
         Container(
-            alignment: AlignmentDirectional.centerStart,
-            margin: EdgeInsets.only(left: 4),
-            child: Text(label)),
+          alignment: AlignmentDirectional.centerStart,
+          margin: EdgeInsets.only(left: 4),
+          child: Text(label),
+        ),
         Padding(
           padding: buttonPadding,
           child: Container(
@@ -338,8 +334,7 @@ class MealSelector extends StatelessWidget {
                         child: DirectSelectList<String>(
                           values: data,
                           defaultItemIndex: 0,
-                          itemBuilder: (String value) =>
-                              getDropDownMenuItem(value),
+                          itemBuilder: (String value) => getDropDownMenuItem(value),
                           focusedItemDecoration: _getDslDecoration(),
                         ),
                         padding: EdgeInsets.only(left: 12))),
@@ -403,14 +398,17 @@ Widget _getFoodContainsRow() {
       children: <Widget>[
         Expanded(
           child: Container(
-              child: Center(child: Text("226")),
-              height: cardSize,
-              margin: EdgeInsets.only(right: 3),
-              decoration: BoxDecoration(
-                  color: cardColor,
-                  borderRadius: BorderRadius.only(
-                      topLeft: const Radius.circular(10.0),
-                      bottomLeft: const Radius.circular(10.0)))),
+            child: Center(child: Text("226")),
+            height: cardSize,
+            margin: EdgeInsets.only(right: 3),
+            decoration: BoxDecoration(
+              color: cardColor,
+              borderRadius: BorderRadius.only(
+                topLeft: const Radius.circular(10.0),
+                bottomLeft: const Radius.circular(10.0),
+              ),
+            ),
+          ),
         ),
         Expanded(
           child: Container(
@@ -428,13 +426,16 @@ Widget _getFoodContainsRow() {
         ),
         Expanded(
           child: Container(
-              child: Center(child: Text("4.5")),
-              height: cardSize,
-              decoration: BoxDecoration(
-                  color: cardColor,
-                  borderRadius: BorderRadius.only(
-                      topRight: const Radius.circular(10.0),
-                      bottomRight: const Radius.circular(10.0)))),
+            child: Center(child: Text("4.5")),
+            height: cardSize,
+            decoration: BoxDecoration(
+              color: cardColor,
+              borderRadius: BorderRadius.only(
+                topRight: const Radius.circular(10.0),
+                bottomRight: const Radius.circular(10.0),
+              ),
+            ),
+          ),
         ),
       ],
     ),

--- a/lib/direct_select_container.dart
+++ b/lib/direct_select_container.dart
@@ -1,10 +1,11 @@
 import 'dart:async';
 
-import 'package:direct_select_flutter/direct_select_list.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:rect_getter/rect_getter.dart';
+
+import './direct_select_list.dart';
 
 /// Root widget for direct select.
 /// This widget displays lists of direct selects.
@@ -86,15 +87,10 @@ class DirectSelectContainer extends StatefulWidget {
   }
 
   static DirectSelectGestureEventListeners of(BuildContext context) {
-    if (context.dependOnInheritedWidgetOfExactType<
-            _InheritedContainerListeners>() ==
-        null) {
-      throw Exception(
-          "A DirectSelectList must inherit a DirectSelectContainer!");
+    if (context.dependOnInheritedWidgetOfExactType<_InheritedContainerListeners>() == null) {
+      throw Exception("A DirectSelectList must inherit a DirectSelectContainer!");
     }
-    return context
-        .dependOnInheritedWidgetOfExactType<_InheritedContainerListeners>()
-        .listeners;
+    return context.dependOnInheritedWidgetOfExactType<_InheritedContainerListeners>().listeners;
   }
 }
 
@@ -104,8 +100,7 @@ class DirectSelectContainerState extends State<DirectSelectContainer>
   bool isOverlayVisible = false;
 
   ScrollController _scrollController;
-  DirectSelectList _currentList =
-      DirectSelectList(itemBuilder: (val) => null, values: []);
+  DirectSelectList _currentList = DirectSelectList(itemBuilder: (val) => null, values: []);
   double _currentScrollLocation = 0;
 
   double _adjustedTopOffset = 0.0;
@@ -141,10 +136,8 @@ class DirectSelectContainerState extends State<DirectSelectContainer>
 
     _adjustedTopOffset = _currentScrollLocation - topOffset;
     _scrollController = ScrollController(
-        initialScrollOffset: listPadding -
-            _currentScrollLocation +
-            topOffset +
-            _currentList.getSelectedItemIndex() * _currentList.itemHeight());
+        initialScrollOffset:
+            listPadding - _currentScrollLocation + topOffset + _currentList.getSelectedItemIndex() * _currentList.itemHeight());
 
     return Stack(
       children: <Widget>[
@@ -155,8 +148,7 @@ class DirectSelectContainerState extends State<DirectSelectContainer>
         Visibility(
           visible: isOverlayVisible,
           child: FadeTransition(
-            opacity: fadeAnimationController
-                .drive(CurveTween(curve: Curves.easeOut)),
+            opacity: fadeAnimationController.drive(CurveTween(curve: Curves.easeOut)),
             child: Column(
               children: <Widget>[
                 Expanded(
@@ -179,8 +171,7 @@ class DirectSelectContainerState extends State<DirectSelectContainer>
     var paddingLeft = 0.0;
 
     if (_currentList.items.isNotEmpty) {
-      Rect rect = RectGetter.getRectFromKey(
-          _currentList.paddingItemController.paddingGlobalKey);
+      Rect rect = RectGetter.getRectFromKey(_currentList.paddingItemController.paddingGlobalKey);
       if (rect != null) {
         paddingLeft = rect.left;
       }
@@ -189,8 +180,7 @@ class DirectSelectContainerState extends State<DirectSelectContainer>
     Decoration dslContainerDecoration;
     if (widget.decoration == null) {
       final theme = Theme.of(context);
-      dslContainerDecoration =
-          BoxDecoration(color: theme.scaffoldBackgroundColor);
+      dslContainerDecoration = BoxDecoration(color: theme.scaffoldBackgroundColor);
     } else {
       dslContainerDecoration = widget.decoration;
     }
@@ -224,23 +214,18 @@ class DirectSelectContainerState extends State<DirectSelectContainer>
         height: _currentList.itemHeight(),
         child: Container(
             height: _currentList.itemHeight(),
-            decoration: _currentList.focusedItemDecoration != null
-                ? _currentList.focusedItemDecoration
-                : BoxDecoration()));
+            decoration: _currentList.focusedItemDecoration != null ? _currentList.focusedItemDecoration : BoxDecoration()));
   }
 
   void performListDrag(double dragDy) {
     try {
       if (_scrollController != null && _scrollController.position != null) {
         final currentScrollOffset = _scrollController.offset;
-        double allowedOffset = _allowedDragDistance(
-            currentScrollOffset + _adjustedTopOffset,
-            dragDy * widget.dragSpeedMultiplier);
+        double allowedOffset = _allowedDragDistance(currentScrollOffset + _adjustedTopOffset, dragDy * widget.dragSpeedMultiplier);
         if (allowedOffset != 0.0) {
           _scrollController.jumpTo(currentScrollOffset + allowedOffset);
 
-          final scrollPixels =
-              _scrollController.offset - listPadding + _adjustedTopOffset;
+          final scrollPixels = _scrollController.offset - listPadding + _adjustedTopOffset;
           final selectedItemIndex = _getCurrentListElementIndex(scrollPixels);
           lastSelectedItem = selectedItemIndex;
 
@@ -254,9 +239,7 @@ class DirectSelectContainerState extends State<DirectSelectContainer>
 
   double _allowedDragDistance(double currentScrollOffset, double position) {
     double newPosition = currentScrollOffset + position;
-    double endOfListPosition =
-        (_currentList.items.length - 1) * _currentList.itemHeight() +
-            listPadding;
+    double endOfListPosition = (_currentList.items.length - 1) * _currentList.itemHeight() + listPadding;
     if (newPosition < listPadding) {
       return listPadding - currentScrollOffset;
     } else if (newPosition > endOfListPosition) {
@@ -268,13 +251,11 @@ class DirectSelectContainerState extends State<DirectSelectContainer>
 
   void _performScaleTransformation(double scrollPixels, int selectedItemIndex) {
     final neighbourDistance = _getNeighbourListElementDistance(scrollPixels);
-    int neighbourIncrementDirection =
-        neighbourScrollDirection(neighbourDistance);
+    int neighbourIncrementDirection = neighbourScrollDirection(neighbourDistance);
 
     int neighbourIndex = lastSelectedItem + neighbourIncrementDirection;
 
-    double neighbourDistanceToCurrentItem =
-        _getNeighbourListElementDistanceToCurrentItem(neighbourDistance);
+    double neighbourDistanceToCurrentItem = _getNeighbourListElementDistanceToCurrentItem(neighbourDistance);
 
     if (neighbourIndex < 0 || neighbourIndex > _currentList.items.length - 1) {
       //incorrect neighbour index quit
@@ -283,14 +264,11 @@ class DirectSelectContainerState extends State<DirectSelectContainer>
     _currentList.items[selectedItemIndex].updateOpacity(1.0);
     _currentList.items[neighbourIndex].updateOpacity(0.5);
 
-    _currentList.items[selectedItemIndex]
-        .updateScale(_calculateNewScale(neighbourDistanceToCurrentItem));
-    _currentList.items[neighbourIndex]
-        .updateScale(_calculateNewScale(neighbourDistance.abs()));
+    _currentList.items[selectedItemIndex].updateScale(_calculateNewScale(neighbourDistanceToCurrentItem));
+    _currentList.items[neighbourIndex].updateScale(_calculateNewScale(neighbourDistance.abs()));
   }
 
-  double _calculateNewScale(double distance) =>
-      1.0 + distance / _currentList.items[lastSelectedItem].scaleFactor;
+  double _calculateNewScale(double distance) => 1.0 + distance / _currentList.items[lastSelectedItem].scaleFactor;
 
   int neighbourScrollDirection(double neighbourDistance) {
     int neighbourScrollDirection = 0;
@@ -302,12 +280,10 @@ class DirectSelectContainerState extends State<DirectSelectContainer>
     return neighbourScrollDirection;
   }
 
-  double _getNeighbourListElementDistanceToCurrentItem(
-      double neighbourDistance) {
+  double _getNeighbourListElementDistanceToCurrentItem(double neighbourDistance) {
     double neighbourDistanceToCurrentItem = (1 - neighbourDistance.abs());
 
-    if (neighbourDistanceToCurrentItem > 1 ||
-        neighbourDistanceToCurrentItem < 0) {
+    if (neighbourDistanceToCurrentItem > 1 || neighbourDistanceToCurrentItem < 0) {
       neighbourDistanceToCurrentItem = 1.0;
     }
     return neighbourDistanceToCurrentItem;
@@ -327,20 +303,16 @@ class DirectSelectContainerState extends State<DirectSelectContainer>
   }
 
   double _getNeighbourListElementDistance(double scrollPixels) {
-    double selectedElementDeviation =
-        (scrollPixels / _currentList.itemHeight());
+    double selectedElementDeviation = (scrollPixels / _currentList.itemHeight());
     int selectedElement = _getCurrentListElementIndex(scrollPixels);
     return selectedElementDeviation - selectedElement;
   }
 
-  Future toggleListOverlayVisibility(
-      DirectSelectList visibleList, double location) async {
+  Future toggleListOverlayVisibility(DirectSelectList visibleList, double location) async {
     if (isOverlayVisible) {
       try {
         await _scrollController.animateTo(
-          listPadding -
-              _adjustedTopOffset +
-              lastSelectedItem * _currentList.itemHeight(),
+          listPadding - _adjustedTopOffset + lastSelectedItem * _currentList.itemHeight(),
           duration: scrollToListElementAnimationDuration,
           curve: Curves.ease,
         );
@@ -379,10 +351,9 @@ class DirectSelectContainerState extends State<DirectSelectContainer>
 }
 
 class DirectSelectGestureEventListeners {
-  toggleListOverlayVisibility(DirectSelectList list, double location) =>
-      throw 'Not implemented.';
+  Future toggleListOverlayVisibility(DirectSelectList list, double location) => throw 'Not implemented.';
 
-  performListDrag(double dragDy) => throw 'Not implemented';
+  void performListDrag(double dragDy) => throw 'Not implemented';
 }
 
 /// Allows Direct Select List implementations to
@@ -396,6 +367,5 @@ class _InheritedContainerListeners extends InheritedWidget {
   }) : super(key: key, child: child);
 
   @override
-  bool updateShouldNotify(_InheritedContainerListeners old) =>
-      old.listeners != listeners;
+  bool updateShouldNotify(_InheritedContainerListeners old) => old.listeners != listeners;
 }


### PR DESCRIPTION
Usable in cases when direct_select is used in a scrollable container, ex. in bottom sheet. With default configuration there is no possibility to close bottom sheet by swipe down gesture as direct_select catches the tapDown and shows the select box. Same behaviour on any screen with a scroll when start scrolling from the position of direct_select. 