### PR TITLE
Clean Up and Migration to PanUpdate

### DIFF
--- a/lib/direct_select_container.dart
+++ b/lib/direct_select_container.dart
@@ -182,7 +182,9 @@ class DirectSelectContainerState extends State<DirectSelectContainer>
       Rect? rect = RectGetter.getRectFromKey(
           _currentList.paddingItemController.paddingGlobalKey);
       if (rect != null) {
-        paddingLeft = rect.left;
+        // paddingLeft = rect.left;
+        paddingLeft = 0;
+        //will leave menus as centered.
       }
     }
 

--- a/lib/direct_select_list.dart
+++ b/lib/direct_select_list.dart
@@ -180,19 +180,46 @@ class DirectSelectState<T> extends State<DirectSelectList<T>> {
                 animatedStateKey.currentState
                     ?.runScaleTransition(reverse: true);
               },
-              onVerticalDragEnd: (dragDetails) async {
+              // onVerticalDragEnd: (dragDetails) async {
+              //   debugPrint('DirectSelectList onVerticalDragEnd');
+              //   transitionEnded = true;
+              //   _dragEnd();
+              // },
+              // onHorizontalDragEnd: (horizontalDetails) async {
+              //   debugPrint('DirectSelectList onVerticalDragEnd');
+              //   transitionEnded = true;
+              //   _dragEnd();
+              // },
+              //   onVerticalDragUpdate: (dragInfo) {
+              //     debugPrint('DirectSelectList onVerticalDragUpdate');
+              //     if (!_isShowUpAnimationRunning) {
+              //       _showListOverlay(dragInfo.primaryDelta);
+              //     }
+              //   },
+              onPanEnd: (dragInfo) async {
+                debugPrint('DirectSelectList onPanEnd');
                 transitionEnded = true;
                 _dragEnd();
               },
-              onHorizontalDragEnd: (horizontalDetails) async {
-                transitionEnded = true;
-                _dragEnd();
-              },
-              onVerticalDragUpdate: (dragInfo) {
-                if (!_isShowUpAnimationRunning) {
-                  _showListOverlay(dragInfo.primaryDelta);
+              onPanUpdate: (dragInfo) {
+                if (dragInfo.delta.dx > 0)
+                  print("Dragging in +X direction");
+                else
+                  print("Dragging in -X direction");
+  
+                if (dragInfo.delta.dy > 0) {
+                  print("Dragging in +Y direction");
+                  if (!_isShowUpAnimationRunning) {
+                    _showListOverlay(dragInfo.delta.dy);
+                  }
+                } else {
+                  print("Dragging in -Y direction");
+                  if (!_isShowUpAnimationRunning) {
+                    _showListOverlay(dragInfo.delta.dy);
+                  }
                 }
-              });
+              },
+          );
         });
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  rect_getter: ^1.0.0
+  rect_getter: ^1.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Because of only using onVerticalDragUpdate, when a user would tap down and drag horizontally, the list would lock up.
Using onPan instead of vertical/horizontal is preferred.  Also updated a dependency centered the list.  

Note: Centering might not be preferred, I am fine to remove that, or perhaps preferably add as a toggle, I just doubt anyone is maintaining this to accept the pull, so I left it in for now.